### PR TITLE
allow router options to be passed in

### DIFF
--- a/lib/curdy.js
+++ b/lib/curdy.js
@@ -69,8 +69,12 @@ module.exports.generateController = (model, modelName, templates, templateOverri
   return controller;
 };
 
-module.exports.generateRoutes = (Controller, isRouting = { create: true, delete: true, show: true, showAll: true, update: true}, idString = ':_id') => {
-  const router = express.Router();
+module.exports.generateRoutes = (Controller, isRouting = { create: true, delete: true, show: true, showAll: true, update: true}, idString = ':_id', routerOpts = {}) => {
+  const router = express.Router(Object.assign({
+    mergeParams: true,
+    strict: false,
+    caseSensitive: false,
+  }, routerOpts));
 
   if (isRouting.create) {
     router.post(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curdy",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Generate CRUD controllers for your express application!",
   "main": "index.js",
   "scripts": {

--- a/spec/express/testApp/controllers/simpleModelWithRouteParams/index.js
+++ b/spec/express/testApp/controllers/simpleModelWithRouteParams/index.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const Controller = require('./simpleModelWithRouteParams.controller');
+const router = express.Router();
+
+const curdy = require('./../../../../../index');
+
+router.use('/:string', curdy.generateRoutes(Controller));
+
+module.exports = router;

--- a/spec/express/testApp/controllers/simpleModelWithRouteParams/simpleModelWithRouteParams.controller.js
+++ b/spec/express/testApp/controllers/simpleModelWithRouteParams/simpleModelWithRouteParams.controller.js
@@ -1,0 +1,33 @@
+const SimpleModel = require('../simpleModel/simpleModel.model');
+const curdy = require('../../../../../index');
+
+Object.assign(
+  module.exports,
+  curdy.generateController(SimpleModel, 'SimpleModel', {
+    find: {
+      _id: 'params._id'
+    },
+    operation: {
+      string: 'params.string',
+      boolean: 'body.boolean',
+      number: 'body.number',
+    },
+    render: {
+      _id: '_id',
+      number: 'number',
+      string: 'string',
+      boolean: 'boolean',
+      paramString: ({ opts }) => opts.req.params.string,
+    }
+  }, {
+    create: {},
+    delete: {},
+    show: {},
+    update: {},
+    showAll: {
+      find: {
+        string: 'params.string'
+      }
+    }
+  }).controller()
+);

--- a/spec/express/testApp/routes.js
+++ b/spec/express/testApp/routes.js
@@ -8,5 +8,6 @@ module.exports = function(app) {
 
   app.use('/helloWorld', require('./controllers/helloWorld'));
   app.use('/simpleModel', require('./controllers/simpleModel'));
+  app.use('/simpleModelWithRouteParams', require('./controllers/simpleModelWithRouteParams'));
   app.use('/plugins', require('./controllers/plugins'));
 };

--- a/spec/express/testAppSpec/controllers/simpleModelWithRouteParams/simpleModelWithRouteParams.integration.spec.js
+++ b/spec/express/testAppSpec/controllers/simpleModelWithRouteParams/simpleModelWithRouteParams.integration.spec.js
@@ -1,0 +1,140 @@
+const Q = require('q');
+const chai = require('chai');
+const request = require('supertest-as-promised');
+
+const expect = chai.expect;
+
+const expressIntegrationHelper = require('./../../express.integrationHelper');
+
+describe('simpleModel.controller.integration.spec', () => {
+  beforeEach(() => {
+    expressIntegrationHelper.beforeEach(this);
+
+    this.SimpleModel = require('./../../../testApp/controllers/simpleModel/simpleModel.model');
+
+    return this.SimpleModel.create({
+      string: 'string',
+      number: 42,
+      date: Date.now(),
+      boolean: true,
+    }).then(simpleModel => {
+      this.simpleModel = simpleModel;
+    });
+  });
+
+  describe('create', () => {
+    it('must create a SimpleModel', () => {
+      return request(this.app)
+      .post('/simpleModelWithRouteParams/123')
+      .send({
+        string: 'not string',
+        number: 43,
+        boolean: false,
+      })
+      .expect(201)
+      .then(({ body }) => {
+
+        expect(body.string).to.equal('123');
+        expect(body.paramString).to.equal('123');
+        expect(body.number).to.equal(43);
+        expect(body.boolean).to.equal(false);
+
+        return this.SimpleModel.findById(body._id);
+      })
+      .then(simpleModel => {
+        expect(simpleModel.string).to.equal('123');
+        expect(simpleModel.number).to.equal(43);
+        expect(simpleModel.boolean).to.equal(false);
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('must delete a SimpleModel', () => {
+      return request(this.app)
+      .delete(`/simpleModelWithRouteParams/123/${this.simpleModel._id}`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.success).to.equal(true);
+
+        return this.SimpleModel.count({ _id: this.simpleModel._id});
+      })
+      .then((simpleModelCount) => {
+        expect(simpleModelCount).to.equal(0);
+      });
+    });
+  });
+
+  describe('show', () => {
+    it('must render a SimpleModel', () => {
+      return request(this.app)
+      .get(`/simpleModelWithRouteParams/asd/${this.simpleModel._id}`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.string).to.equal(this.simpleModel.string);
+        expect(body.paramString).to.equal('asd');
+        expect(body.number).to.equal(this.simpleModel.number);
+        expect(body.boolean).to.equal(this.simpleModel.boolean);
+      });
+    });
+  });
+
+  describe('showAll', () => {
+    beforeEach(() => {
+      return this.SimpleModel.remove({})
+      .then(() => {
+        return Q.all([
+          this.SimpleModel.create({
+            string: '123',
+            number: 42,
+            date: Date.now(),
+            boolean: true
+          }),
+          this.SimpleModel.create({
+            string: 'not string',
+            number: 43,
+            date: Date.now(),
+            boolean: false
+          })
+        ]);
+      });
+    });
+    it('must render a SimpleModel', () => {
+      return request(this.app)
+      .get('/simpleModelWithRouteParams/123')
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.length).to.equal(1);
+        expect(body[0].string).to.equal('123');
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('must create a SimpleModel', () => {
+      const newString = 'asdfoasidjf';
+      return request(this.app)
+      .put(`/simpleModelWithRouteParams/${newString}/${this.simpleModel._id}`)
+      .send({
+        string: 'not string',
+        number: 43,
+        boolean: false
+      })
+      .expect(200)
+      .then(({ body }) => {
+        expect(body._id).to.equal(this.simpleModel._id.toString());
+        expect(body.string).to.equal(newString);
+        expect(body.number).to.equal(43);
+        expect(body.boolean).to.equal(false);
+
+        return this.SimpleModel.findById(body._id);
+      })
+      .then((simpleModel) => {
+        expect(simpleModel.string).to.equal(newString);
+        expect(simpleModel.number).to.equal(43);
+        expect(simpleModel.boolean).to.equal(false);
+      });
+    });
+  });
+
+});

--- a/spec/lib/router.spec.js
+++ b/spec/lib/router.spec.js
@@ -1,0 +1,27 @@
+require('./../helpers');
+const chai = require('chai');
+const expect = chai.expect;
+const curdy = require('../../lib/curdy');
+const SimpleModel = require('../models/simpleModel.model');
+
+describe('router.spec', () => {
+  describe('router options', () => {
+    it('should allow router options to be passed in', () => {
+      const routerOpts = {
+        caseSensitive: false,
+        mergeParams: true,
+        strict: false,
+      };
+      const router = curdy.generateRoutes(
+        curdy.generateController(SimpleModel, 'SimpleModel', {}).controller(),
+        {},
+        ':_id',
+        routerOpts
+      );
+
+      expect(router.caseSensitive).to.equal(routerOpts.caseSensitive);
+      expect(router.mergeParams).to.equal(routerOpts.mergeParams);
+      expect(router.strict).to.equal(routerOpts.strict);
+    });
+  });
+});


### PR DESCRIPTION
- added router options as the 4th parameter to `curdy.generateRoutes`
- it solves `retailerId` is not available to curdy routes  when `router.use('/:retailerId', curdy.generateRoutes(...))`